### PR TITLE
fix: encode Vector{Pair}, NamedTuple, and Tuple of Pairs as objects

### DIFF
--- a/test/test_namedtuple_encoding.jl
+++ b/test/test_namedtuple_encoding.jl
@@ -1,0 +1,91 @@
+# Copyright (c) 2025 TOON Format Organization
+# SPDX-License-Identifier: MIT
+
+"""
+Tests for NamedTuple encoding (Issue #9).
+
+NamedTuple should be encoded as TOON objects, equivalent to OrderedDict.
+"""
+
+using Test
+using ToonFormat
+using OrderedCollections
+
+@testset "NamedTuple Encoding" begin
+    @testset "Basic Encoding" begin
+        # Single field
+        @test encode((a=1,)) == "a: 1"
+
+        # Multiple fields
+        @test encode((b=1, a=2)) == "b: 1\na: 2"
+
+        # Matches OrderedDict output
+        tuple_data = (b=1, a=2)
+        dict_data = OrderedDict("b"=>1, "a"=>2)
+        @test encode(tuple_data) == encode(dict_data)
+
+        # String values
+        @test encode((name="Alice", city="Paris")) == "name: Alice\ncity: Paris"
+    end
+
+    @testset "Edge Cases" begin
+        # Empty NamedTuple
+        @test encode(NamedTuple()) == ""
+
+        # Single field with array value
+        @test encode((items=[1,2,3],)) == "items[3]: 1,2,3"
+
+        # Nested NamedTuple
+        nested = (outer=(inner=42,),)
+        @test encode(nested) == "outer:\n  inner: 42"
+
+        # Mixed value types
+        mixed = (str="hello", num=42, flag=true, nil=nothing)
+        result = encode(mixed)
+        @test occursin("str: hello", result)
+        @test occursin("num: 42", result)
+        @test occursin("flag: true", result)
+        @test occursin("nil: null", result)
+    end
+
+    @testset "Array Values" begin
+        # NamedTuple with array value
+        with_array = (name="Alice", scores=[90, 85, 92])
+        @test encode(with_array) == "name: Alice\nscores[3]: 90,85,92"
+
+        # NamedTuple with nested array of objects
+        complex = (items=[Dict("id"=>1), Dict("id"=>2)],)
+        @test occursin("items[2]{id}:", encode(complex))
+    end
+
+    @testset "Nested Structures" begin
+        # NamedTuple with Dict value
+        with_dict = (config=Dict("key"=>"value"),)
+        @test occursin("config:", encode(with_dict))
+
+        # Deeply nested NamedTuple
+        deep = (level1=(level2=(level3=42,),),)
+        result = encode(deep)
+        @test occursin("level1:", result)
+        @test occursin("level2:", result)
+        @test occursin("level3: 42", result)
+    end
+
+    @testset "Round-trip Consistency" begin
+        # Basic round-trip
+        tuple_data = (x=10, y=20)
+        decoded = decode(encode(tuple_data))
+        @test decoded["x"] == 10
+        @test decoded["y"] == 20
+
+        # Round-trip with nested structure
+        nested = (outer=(inner=42,),)
+        decoded = decode(encode(nested))
+        @test decoded["outer"]["inner"] == 42
+
+        # Round-trip with array values
+        with_array = (items=[1, 2, 3],)
+        decoded = decode(encode(with_array))
+        @test decoded["items"] == [1, 2, 3]
+    end
+end

--- a/test/test_pair_encoding.jl
+++ b/test/test_pair_encoding.jl
@@ -1,0 +1,86 @@
+# Copyright (c) 2025 TOON Format Organization
+# SPDX-License-Identifier: MIT
+
+"""
+Tests for Vector{Pair} encoding (Issue #8).
+
+Vector of pairs should be encoded as TOON objects, equivalent to OrderedDict.
+"""
+
+using Test
+using ToonFormat
+using OrderedCollections
+
+@testset "Vector{Pair} Encoding" begin
+    @testset "Basic Encoding" begin
+        # Single pair
+        @test encode(["a"=>1]) == "a: 1"
+
+        # Multiple pairs
+        @test encode(["b"=>1, "a"=>2]) == "b: 1\na: 2"
+
+        # Matches OrderedDict output
+        pairs_data = ["b"=>1, "a"=>[1,2,3]]
+        dict_data = OrderedDict("b"=>1, "a"=>[1,2,3])
+        @test encode(pairs_data) == encode(dict_data)
+
+        # String values
+        @test encode(["name"=>"Alice", "city"=>"Paris"]) == "name: Alice\ncity: Paris"
+    end
+
+    @testset "Edge Cases" begin
+        # Empty vector of pairs
+        @test encode(Pair{String,Any}[]) == ""
+
+        # Single pair with array value
+        @test encode(["items"=>[1,2,3]]) == "items[3]: 1,2,3"
+
+        # Nested pairs (pair value is another vector of pairs)
+        nested = ["outer"=>["inner"=>42]]
+        @test encode(nested) == "outer:\n  inner: 42"
+
+        # Non-string keys (symbols) - should coerce to string
+        @test encode([:a=>1, :b=>2]) == "a: 1\nb: 2"
+
+        # Mixed value types
+        mixed = ["str"=>"hello", "num"=>42, "bool"=>true, "nil"=>nothing]
+        result = encode(mixed)
+        @test occursin("str: hello", result)
+        @test occursin("num: 42", result)
+        @test occursin("bool: true", result)
+        @test occursin("nil: null", result)
+    end
+
+    @testset "Duplicate Keys" begin
+        # Last value wins
+        @test encode(["a"=>1, "b"=>2, "a"=>999]) == "a: 999\nb: 2"
+    end
+
+    @testset "Nested Structures" begin
+        # Pair with dict value
+        with_dict = ["config"=>Dict("key"=>"value")]
+        @test occursin("config:", encode(with_dict))
+
+        # Pair with nested array of objects (uses tabular format)
+        complex = ["items"=>[Dict("id"=>1), Dict("id"=>2)]]
+        @test occursin("items[2]{id}:", encode(complex))
+    end
+
+    @testset "Round-trip Consistency" begin
+        # Basic round-trip
+        pairs = ["x"=>10, "y"=>20]
+        decoded = decode(encode(pairs))
+        @test decoded["x"] == 10
+        @test decoded["y"] == 20
+
+        # Round-trip with nested structure
+        nested = ["outer"=>["inner"=>42]]
+        decoded = decode(encode(nested))
+        @test decoded["outer"]["inner"] == 42
+
+        # Round-trip with array values
+        with_array = ["items"=>[1, 2, 3]]
+        decoded = decode(encode(with_array))
+        @test decoded["items"] == [1, 2, 3]
+    end
+end

--- a/test/test_tuple_pairs_encoding.jl
+++ b/test/test_tuple_pairs_encoding.jl
@@ -1,0 +1,109 @@
+# Copyright (c) 2025 TOON Format Organization
+# SPDX-License-Identifier: MIT
+
+"""
+Tests for Tuple of Pairs encoding (Issue #10).
+
+Tuples containing only Pair elements should be encoded as TOON objects.
+Regular tuples (mixed content) should still encode as arrays.
+"""
+
+using Test
+using ToonFormat
+using OrderedCollections
+
+@testset "Tuple of Pairs Encoding" begin
+    @testset "Basic Encoding" begin
+        # Single pair tuple
+        @test encode((:a=>1,)) == "a: 1"
+
+        # Multiple pairs
+        @test encode((:b=>1, :a=>2)) == "b: 1\na: 2"
+
+        # Matches OrderedDict output
+        tuple_pairs = (:b=>1, :a=>2)
+        dict_data = OrderedDict("b"=>1, "a"=>2)
+        @test encode(tuple_pairs) == encode(dict_data)
+
+        # String keys in tuple of pairs
+        @test encode(("name"=>"Alice", "city"=>"Paris")) == "name: Alice\ncity: Paris"
+    end
+
+    @testset "Edge Cases" begin
+        # Single pair with array value
+        @test encode((:items=>[1,2,3],)) == "items[3]: 1,2,3"
+
+        # Nested tuple of pairs
+        nested = (:outer=>(:inner=>42,),)
+        @test encode(nested) == "outer:\n  inner: 42"
+
+        # Symbol keys converted to strings
+        @test encode((:a=>1, :b=>2)) == "a: 1\nb: 2"
+
+        # Mixed value types
+        mixed = (:str=>"hello", :num=>42, :flag=>true, :nil=>nothing)
+        result = encode(mixed)
+        @test occursin("str: hello", result)
+        @test occursin("num: 42", result)
+        @test occursin("flag: true", result)
+        @test occursin("nil: null", result)
+    end
+
+    @testset "Duplicate Keys" begin
+        # Last value wins
+        dupes = (:a=>1, :b=>2, :a=>3)
+        @test encode(dupes) == "a: 3\nb: 2"
+    end
+
+    @testset "Mixed Tuples (Not All Pairs)" begin
+        # Mixed tuple - NOT all pairs, encodes as array
+        mixed = (1, :a=>2, "hello")
+        result = encode(mixed)
+        @test startswith(result, "[3]:")
+
+        # Regular tuple without pairs - should encode as array
+        regular = (1, 2, 3)
+        @test encode(regular) == "[3]: 1,2,3"
+
+        # Tuple with some non-pair elements - array
+        some_pairs = (1, :a=>2)
+        @test startswith(encode(some_pairs), "[2]:")
+    end
+
+    @testset "Array Values" begin
+        # Tuple of pairs with array value
+        with_array = (:name=>"Alice", :scores=>[90, 85])
+        @test encode(with_array) == "name: Alice\nscores[2]: 90,85"
+    end
+
+    @testset "Nested Structures" begin
+        # Tuple of pairs with Dict value
+        with_dict = (:config=>Dict("key"=>"value"),)
+        @test occursin("config:", encode(with_dict))
+
+        # Deeply nested tuple of pairs
+        deep = (:level1=>(:level2=>(:level3=>42,),),)
+        result = encode(deep)
+        @test occursin("level1:", result)
+        @test occursin("level2:", result)
+        @test occursin("level3: 42", result)
+    end
+
+    @testset "Round-trip Consistency" begin
+        # Basic round-trip
+        tuple_pairs = (:x=>10, :y=>20)
+        decoded = decode(encode(tuple_pairs))
+        @test decoded["x"] == 10
+        @test decoded["y"] == 20
+
+        # Round-trip with nested structure
+        nested = (:outer=>(:inner=>42,),)
+        decoded = decode(encode(nested))
+        @test decoded["outer"]["inner"] == 42
+
+        # Round-trip with array values
+        with_array = (:items=>[1, 2, 3],)
+        decoded = decode(encode(with_array))
+        @test decoded["items"] == [1, 2, 3]
+    end
+end


### PR DESCRIPTION
## Linked Issue

Closes #8, closes #9, closes #10

## Description

Fix three related encoding bugs where object-like Julia types were incorrectly serialized:

- Vector{Pair} was producing string representations of Pair objects
- NamedTuple was producing a quoted string like "(b = 1, a = 2)"
- Tuple of Pairs was producing indexed array format

All three types now correctly encode as TOON objects, equivalent to OrderedDict output. The fix adds type checks in normalize_value() before existing handlers to convert these types to OrderedDict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Type of Change

<!-- Mark the relevant option with an [x] -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

<!-- List the main changes in this PR -->

-
-
-

## SPEC Compliance

<!-- If this PR relates to the TOON spec, indicate which sections are affected -->

- [ ] This PR implements/fixes spec compliance
- [ ] Spec section(s) affected:
- [ ] Spec version:

## Testing

<!-- Describe the tests you added or ran -->

- [ ] All existing tests pass
- [ ] Added new tests for changes
- [ ] Tests cover edge cases and spec compliance

## Pre-submission Checklist

<!-- Verify before submitting -->

- [x] My code follows the project's coding standards
- [ ] I have run code formatting/linting tools
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
- [x] I have reviewed the [TOON specification](https://github.com/toon-format/spec) for relevant sections

## Breaking Changes

<!-- If this is a breaking change, describe the migration path for users -->

- [x] No breaking changes
- [ ] Breaking changes (describe migration path below)

<!-- Migration path: -->

## Additional Context

<!-- Add any other context about the PR here (optional) -->
